### PR TITLE
Fix incorrect metric exporter error

### DIFF
--- a/otel/metric.go
+++ b/otel/metric.go
@@ -38,7 +38,7 @@ func NewMeterProvider(cfg config.MetricConfig, res *resource.Resource) (metric.M
 	} else if protocol == "noop" {
 		exporter = nil
 	} else {
-		return nil, fmt.Errorf("invalid trace exporter protocol: %s", protocol)
+		return nil, fmt.Errorf("invalid metric exporter protocol: %s", protocol)
 	}
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary
- fix incorrect error message for invalid metric exporter protocol

## Testing
- `go vet ./...` *(fails: github.com/klauspost/compress not accessible)*

------
https://chatgpt.com/codex/tasks/task_e_684055743e6c832fae90b1a6265dda1c