### PR TITLE
Fix RandString comment style

### DIFF
--- a/secure/strings.go
+++ b/secure/strings.go
@@ -10,7 +10,7 @@ const (
 	DefaultPasswordSymbols = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%^&*()-_=+,.?/:;{}[]`~"
 )
 
-// RandString randomly generates l length string from the given symbols.
+// RandString randomly generates a string of length l from the given symbols.
 func RandString(l int, s string) (string, error) {
 	if s == "" || l <= 0 {
 		return "", nil


### PR DESCRIPTION
## Summary
- update comment for `secure.RandString`

## Testing
- `go test ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68405532d3f4832f87749d82b9390060