### PR TITLE
Fix token expiration logic

### DIFF
--- a/secure/token.go
+++ b/secure/token.go
@@ -74,7 +74,7 @@ func (t *Token) ExpiresAt() time.Time {
 }
 
 func (t *Token) IsExpired() bool {
-	return !t.expiresAt.IsZero() && t.expiresAt.After(time.Now().UTC())
+	return !t.expiresAt.IsZero() && t.expiresAt.Before(time.Now().UTC())
 }
 
 // TokenStore used to manage tokens.


### PR DESCRIPTION
## Summary
- fix expiration check in secure token implementation

## Testing
- `go vet ./...` *(fails: Forbidden fetching module)*
- `go build ./...` *(fails: Forbidden fetching module)*

------
https://chatgpt.com/codex/tasks/task_e_684053d79878832f8f7f8fb75826c205